### PR TITLE
Fix crashing after cancel not existing notification

### DIFF
--- a/PluginSrc/src/net/agasper/unitynotification/UnityNotificationManager.java
+++ b/PluginSrc/src/net/agasper/unitynotification/UnityNotificationManager.java
@@ -140,8 +140,12 @@ public class UnityNotificationManager extends BroadcastReceiver
         Activity currentActivity = UnityPlayer.currentActivity;
         AlarmManager am = (AlarmManager)currentActivity.getSystemService(Context.ALARM_SERVICE);
         Intent intent = new Intent(currentActivity, UnityNotificationManager.class);
-        PendingIntent pendingIntent = PendingIntent.getBroadcast(currentActivity, id, intent, 0);
-        am.cancel(pendingIntent);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(currentActivity, id, intent, PendingIntent.FLAG_NO_CREATE);
+        if (pendingIntent != null)
+        {
+            am.cancel(pendingIntent);
+            pendingIntent.cancel();
+        }
     }
 
     public static void CancelAll(){


### PR DESCRIPTION
After cancel not existing notification, if I set new, it crashes with log:

> AndroidRuntime: Caused by: java.lang.RuntimeException: Unable to start receiver net.agasper.unitynotification.UnityNotificationManager: java.lang.NullPointerException
> AndroidRuntime:        at android.app.ActivityThread.handleReceiver(ActivityThread.java:2739)
> AndroidRuntime:        at android.app.ActivityThread.access$1800(ActivityThread.java:153)
> AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1428)
> AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:102)
> AndroidRuntime:        at android.os.Looper.loop(Looper.java:148)
> AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:5441)
> AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
> AndroidRuntime:        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:738)
> AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:628)
> AndroidRuntime: Caused by: java.lang.NullPointerException
> AndroidRuntime:        at java.lang.Class.classForName(Native Method)
> AndroidRuntime:        at java.lang.Class.forName(Class.java:324)
> AndroidRuntime:        at java.lang.Class.forName(Class.java:285)
> AndroidRuntime:        at net.agasper.unitynotification.UnityNotificationManager.onReceive(UnityNotificationManager.java:95)
> AndroidRuntime:        at android.app.ActivityThread.handleReceiver(ActivityThread.java:2732)
> AndroidRuntime:        ... 8 more
> ActivityManager: Invalid thumbnail dimensions: 0x0