### PR TITLE
Fix to issue: Push notification crash when app is closed #83

### DIFF
--- a/PluginSrc/app/src/main/java/net/agasper/unitynotification/UnityNotificationManager.java
+++ b/PluginSrc/app/src/main/java/net/agasper/unitynotification/UnityNotificationManager.java
@@ -1,5 +1,6 @@
 package net.agasper.unitynotification;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.Notification;
@@ -69,6 +70,12 @@ public class UnityNotificationManager extends BroadcastReceiver
                                        int lights, String largeIconResource, String smallIconResource, int bgColor, String bundle, String channel,
                                        ArrayList<NotificationAction> actions)
     {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (channel == null)
+                channel = "default";
+            createChannelIfNeeded(channel, title, soundName, lights == 1, vibrate == 1, bundle);
+        }
+
         Activity currentActivity = UnityPlayer.currentActivity;
         AlarmManager am = (AlarmManager)currentActivity.getSystemService(Context.ALARM_SERVICE);
         Intent intent = new Intent(currentActivity, UnityNotificationManager.class);
@@ -97,6 +104,12 @@ public class UnityNotificationManager extends BroadcastReceiver
     public static void SetRepeatingNotification(int id, long delayMs, String title, String message, String ticker, long rep, int sound, String soundName, int vibrate, int lights,
                                                 String largeIconResource, String smallIconResource, int bgColor, String bundle, String channel, ArrayList<NotificationAction> actions)
     {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (channel == null)
+                channel = "default";
+            createChannelIfNeeded(channel, title, soundName, lights == 1, vibrate == 1, bundle);
+        }
+
         Activity currentActivity = UnityPlayer.currentActivity;
         AlarmManager am = (AlarmManager)currentActivity.getSystemService(Context.ALARM_SERVICE);
         Intent intent = new Intent(currentActivity, UnityNotificationManager.class);
@@ -151,9 +164,6 @@ public class UnityNotificationManager extends BroadcastReceiver
 
         if (channel == null)
             channel = "default";
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            createChannelIfNeeded(channel, title, soundName, lights, vibrate, bundle);
-        }
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channel);
 


### PR DESCRIPTION
Android 8.x crashes if the notification is received while app is closed. This is due to channel creation, which leads to NullPointerException if done while app is not initially running. The notification channel creation should be done before creating the notification.