### PR TITLE
Fix PendingIntent is not passsed to onReceive method

### DIFF
--- a/PluginSrc/app/src/main/java/net/agasper/unitynotification/UnityNotificationManager.java
+++ b/PluginSrc/app/src/main/java/net/agasper/unitynotification/UnityNotificationManager.java
@@ -129,7 +129,7 @@ public class UnityNotificationManager extends BroadcastReceiver
         Bundle b = new Bundle();
         b.putParcelableArrayList("actions", actions);
         intent.putExtra("actionsBundle", b);
-        am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + delayMs, rep, PendingIntent.getBroadcast(currentActivity, id, intent, 0));
+        am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + delayMs, rep, PendingIntent.getBroadcast(currentActivity, id, intent, PendingIntent.FLAG_UPDATE_CURRENT));
     }
 
     public void onReceive(Context context, Intent intent)


### PR DESCRIPTION
When I passed a PendingIntent to AlarmManager and later receive it via via onReceive method, it returns null. As it is stated in this thread I think we have to change a little bit : https://stackoverflow.com/questions/18649728/android-cannot-pass-intent-extras-though-alarmmanager/41429570#41429570

Moreover, there is still an issue which is reported and unsolved. As it is also stated on the above link, we have to marshal Parcelable object into bytes array to pass to onReceive method later. That's why it's always null when calling bundle.getBundleExtra and crash the notification.

Now I have not fixed the Parcelable yet, only make a null check to make it run because my app does not need "action" now, but if I have time I will fix this if you do not have time maintain this project.